### PR TITLE
chore: Add CODEOWNERS file for code review requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @OColmignoli will be requested for review when someone 
+# opens a pull request.
+*       @OColmignoli
+
+# ML Model files
+/src/models/       @OColmignoli
+/src/training/     @OColmignoli
+
+# Data processing
+/src/data/         @OColmignoli
+
+# CI/CD and Infrastructure
+/.github/          @OColmignoli
+/infrastructure/   @OColmignoli


### PR DESCRIPTION
This PR adds a CODEOWNERS file to establish code review requirements for different parts of the codebase.

Changes:
- Created [.github/CODEOWNERS](cci:7://file:///Users/olli/CascadeProjects/olli-forecast-sales-v2/.github/CODEOWNERS:0:0-0:0) file
- Defined ownership for:
  - ML model files (/src/models/, /src/training/)
  - Data processing (/src/data/)
  - CI/CD and Infrastructure (/.github/, /infrastructure/)
  - Default ownership for all other files

This ensures proper code review requirements are enforced and the right people are notified for changes in their areas of responsibility.